### PR TITLE
Improve logging on panic

### DIFF
--- a/join.go
+++ b/join.go
@@ -96,7 +96,7 @@ func runJoinActionsInParallel(ctx context.Context, actions ...Action) (result ct
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					*panicRef = fmt.Sprintf("Action '%s' panicked with '%v'", act.Description(), r)
+					*panicRef = fmt.Sprintf("Action  '%s' panicked with '%v'", act.Description(), r)
 				}
 				wg.Done()
 			}()

--- a/join.go
+++ b/join.go
@@ -96,7 +96,7 @@ func runJoinActionsInParallel(ctx context.Context, actions ...Action) (result ct
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					*panicRef = fmt.Sprintf("Action  '%s' panicked with '%v'", act.Description(), r)
+					*panicRef = fmt.Sprintf("Action '%s' panicked with '%v'", act.Description(), r)
 				}
 				wg.Done()
 			}()

--- a/join.go
+++ b/join.go
@@ -18,6 +18,7 @@ package ctrlkit
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/samber/lo"
@@ -95,7 +96,7 @@ func runJoinActionsInParallel(ctx context.Context, actions ...Action) (result ct
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					*panicRef = r
+					*panicRef = fmt.Sprintf("Action '%s' panicked with '%v'", act.Description(), r)
 				}
 				wg.Done()
 			}()


### PR DESCRIPTION
If you have many different actions running it is hard to know which one actually panicked. This is a small improvement that helps you if your panic is generic like e.g. null ptr deref.

New panic message: 

```
"Action 'CollectRunningStatisticsAndSyncStatusForStandalone' panicked with 'runtime error: invalid memory address or nil pointer dereference'"
```